### PR TITLE
Fixing several completion errors.

### DIFF
--- a/addon/data/browserid/channel.js
+++ b/addon/data/browserid/channel.js
@@ -5,6 +5,7 @@ nav.id = nav.id || {};
 nav.id.channel = nav.id.channel || {};
 
 let browseridController;
+let complete;
 
 nav.id.channel.registerController = function(controller) {
     browseridController = controller;    
@@ -20,14 +21,23 @@ self.port.on("getVerifiedEmail", function(payload) {
 });
 
 function onGetAssertionSuccess(assertion) {
-    self.port.emit("assertionReady", {
+    emit("assertionReady", {
         assertion: assertion
     });
 }
 
 function onGetAssertionFailure(reason) {
-    self.port.emit("assertionFailure", {
+    emit("assertionFailure", {
         reason: reason
     });
+}
+
+function emit(message, payload) {
+    // Only send a message if we haven't already sent one, otherwise we can get 
+    // into confusing states.
+    if(!complete) {
+        complete = true;
+        self.port.emit(message, payload); 
+    }
 }
 


### PR DESCRIPTION
First when clicking out of the panel we should send back an error.
Second, when switching tabs, we should send back an error.
Third, if we have already sent a completion message, do not send another.
