### PR TITLE
Issue/70 iframe steals all events

### DIFF
--- a/addon/lib/sessions/main_module.js
+++ b/addon/lib/sessions/main_module.js
@@ -63,7 +63,6 @@ exports.MainSession = function() {
            * contents.
            */
           if (worker.tab) {
-              worker.tab.worker = worker;
               worker.port.on("sessions.set", onSessionSet.bind(worker));
               worker.port.on("sessions.opentab", onSessionTabOpen.bind(worker));
               worker.port.on("sessions.tabready", onSessionTabReady.bind(worker));
@@ -95,6 +94,7 @@ exports.MainSession = function() {
    * remove it if there is no session data.
    */
   function onSessionTabReady() {
+      this.tab.worker = this;
       tabManager.tabReady(this.tab);
   };
 

--- a/addon/test-site/run.js
+++ b/addon/test-site/run.js
@@ -20,6 +20,12 @@ app.get("/set_login.html", function(req, res) {
   });
 });
 
+app.get("/set_login_with_iframe.html", function(req, res) {
+  res.render("set_login_with_iframe.ejs", {
+    title: "Login without cookie, add iframe"
+  });
+});
+
 app.get("/set_cookie.html", function(req, res) {
   res.cookie("SID", "fakeSID");
   res.render("set_cookie.ejs", {

--- a/addon/test-site/views/layout.ejs
+++ b/addon/test-site/views/layout.ejs
@@ -11,6 +11,8 @@
       <li><a href="/">Main</a></li>
       <li><a href="set_login.html">Set the login info, no cookie</a></li>
       <li><a href="set_cookie.html">Set the login info, with cookie</a></li>
+      <li><a href="set_login_with_iframe.html">Set the login info, have an 
+        IFRAME, no cookie</a></li>
       <li><a href="logout.html">Logout, clear cookies</a></li>
     </ul>
 

--- a/addon/test-site/views/set_login_with_iframe.ejs
+++ b/addon/test-site/views/set_login_with_iframe.ejs
@@ -1,0 +1,13 @@
+You should now be logged in, but no cookie information was set.
+<script type="text/javascript">
+  navigator.id = navigator.id || {};
+
+  navigator.id.sessions = [
+    {
+      email: 'labs@mozilla.com'
+    }
+  ];
+</script>
+
+<iframe src="http://www.mozilla.com"></iframe>
+


### PR DESCRIPTION
This fixes issue 70 where iframes steal all events for a page.  I am not sure if this is a great fix, as it means that only the top level page can set the navigator.id.sessions for a page.  But at the same time, this seems reasonable.
